### PR TITLE
Ensure frame fills parent

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,14 @@
 @import 'tailwindcss';
 
+html,
+body,
+#root {
+  height: 100%;
+  width: 100%;
+}
+
 body {
   font-family: sans-serif;
   margin: 0;
-  height: 100%;
   overflow: auto;
 }


### PR DESCRIPTION
## Summary
- ensure the widget fills the parent's space by setting html/body/root to `100%`

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_685cce48151c832bb5dc7a5d05cfd172